### PR TITLE
fix: proper handling with empty structures

### DIFF
--- a/src/timeranges/_timeranges.py
+++ b/src/timeranges/_timeranges.py
@@ -94,6 +94,8 @@ class TimeRanges:
         self.validate()
 
     def contains(self, t: time) -> bool:
+        if self.time_ranges == []:
+            return True
         return any(t in time_range for time_range in self.time_ranges)
 
     def __contains__(self, t: time) -> bool:
@@ -120,6 +122,8 @@ class WeekRange:
         tz = self.timezone
         if tz is not None:
             dt = dt.astimezone(tz)
+        if self.day_ranges == {}:
+            return True
         weekday = Weekday.from_datetime(dt)
         day_range = self.day_ranges.get(weekday)
         if day_range is not None:


### PR DESCRIPTION
As presented in https://github.com/tractian/tractian-python-sdk/issues/30#issuecomment-993901186,
- empty dictionary in `day_ranges` means all days, with this, any datetime should return `True` in `__contains__`
- empty list in `time_ranges` means all hours, with this, any datetime at the same weekday should return `True` in `__contains__`
The actual PR is a suggestion to this behavior works, which is not working properly.

#### Examples of misleading behavior:
- Datetime in a weekday with empty list as time_ranges
![image](https://user-images.githubusercontent.com/87147610/147485426-20583b09-0c37-46a0-93db-49ee028a52bc.png)
- Datetime not in a empty dict as day_ranges
![image](https://user-images.githubusercontent.com/87147610/147485620-aaf3e5eb-869e-4699-9f34-2f79e349ef1e.png)
